### PR TITLE
feat(workflow): add GitHub Actions workflows for branch

### DIFF
--- a/.github/workflows/conventional_branch.yml
+++ b/.github/workflows/conventional_branch.yml
@@ -1,0 +1,23 @@
+name: "Branch Naming Convention"
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+      - master
+    types: [opened, synchronize, reopened]
+
+jobs:
+  enforce-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: deepakputhraya/action-branch-name@master
+        with:
+          regex: '^(feature|bugfix|chore)\/[a-z0-9\-]+$|^(hotfix\/[a-z0-9\-]+)|^(release\/[0-9]+\.[0-9]+\.[0-9]+)$'
+          ignore: |
+            master
+            main
+            develop
+          min_length: 8
+          max_length: 60

--- a/.github/workflows/deploy_main.yml
+++ b/.github/workflows/deploy_main.yml
@@ -1,0 +1,22 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v20
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }} # seu token da Vercel
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }} # ID da sua organização
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }} # ID do projeto
+          working-directory: ./
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate branch naming enforcement and deployment to Vercel. These changes improve repository standards and streamline the deployment process for the `main` branch.

Repository standards:

* Added `.github/workflows/conventional_branch.yml` to enforce branch naming conventions for pull requests targeting `main`, `develop`, or `master`, using a regex pattern and length restrictions.

Deployment automation:

* Added `.github/workflows/deploy_main.yml` to automatically deploy the project to Vercel when changes are pushed to the `main` branch, using the `amondnet/vercel-action`.